### PR TITLE
Update start_service.template

### DIFF
--- a/ServiceWizard.spec
+++ b/ServiceWizard.spec
@@ -4,6 +4,9 @@ module ServiceWizard {
     
     typedef int boolean;
 
+    /* Get the version of the deployed service wizard endpoint. */
+    funcdef version() returns (string version);
+
     /*
         version - unified version field including semantic version, git commit hash and
             case of last version of tag (dev/beta/release).

--- a/service/start_service.template
+++ b/service/start_service.template
@@ -42,7 +42,7 @@ uwsgi --master \
 echo "$KB_SERVICE_NAME started on port $port."
 echo "Errors are logged to: $KB_SERVICE_DIR/error.log"
 echo "Checking version to see if things successfully started up..."
-VERSION=$(curl -s -d '{{"params":[],"method":"Catalog.version","version":"1.1","id":"5313251235"}}' http://localhost:$port)
+VERSION=$(curl -s -d '{{"params":[],"method":"ServiceWizard.version","version":"1.1","id":"5313251235"}}' http://localhost:$port)
 if [ 0 -eq $? ]
 then
     echo $VERSION | python -c 'import sys, json; print(" -> up and running: "+json.load(sys.stdin)["result"][0])'


### PR DESCRIPTION
The startup check was asking for Catalog.version instead of ServiceWizard.version.  (We may want to use $KB_SERVICE_NAME if that matches, but for now this should be sufficient.)

There's currently no ver() method in ServiceWizard so this part will fail anyway; we should add one later but it's not essential at the moment.