### PR TITLE
Handle error from catalog in list_service_status

### DIFF
--- a/ServiceWizard.spec
+++ b/ServiceWizard.spec
@@ -16,11 +16,11 @@ module ServiceWizard {
         string version;
     } Service;
 
-
+    /* version is the semantic version of the module */
     typedef structure {
         string module_name;
 
-        string semantic_version;
+        string version;
         string hash;
 
         string url;


### PR DESCRIPTION
If a service is not registered in the catalog, but was still deployed in rancher, the catalog service will throw an error.  This PR adds code to catch the error.  This PR also adds version info to the service status return (basically passing on that info from the catalog).